### PR TITLE
Change rust-sha1 URL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["websocket", "websockets", "rfc6455"]
 license = "MIT"
 
 [dependencies.sha1]
-git = "https://github.com/zsiciarz/rust-sha1.git"
+git = "https://github.com/cyderize/rust-sha1.git"
 
 [dependencies]
 hyper = "~0.0.20"


### PR DESCRIPTION
The version pointed to previously is out of date with regards to Rust nightly