### PR TITLE
Strip hyphens from `extern crate`

### DIFF
--- a/examples/autobahn-client.rs
+++ b/examples/autobahn-client.rs
@@ -1,5 +1,5 @@
 extern crate websocket;
-extern crate "rustc-serialize" as serialize;
+extern crate rustc_serialize as serialize;
 
 use websocket::client::request::Url;
 use websocket::{Client, Message, Sender, Receiver};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 extern crate hyper;
 extern crate unicase;
 extern crate url;
-extern crate "rustc-serialize" as serialize;
+extern crate rustc_serialize as serialize;
 extern crate openssl;
 extern crate rand;
 extern crate byteorder;


### PR DESCRIPTION
The build fails due to the changes introduced by RFC 940.