### PR TITLE
Remove cast warning and fix indentation in src/result.rs

### DIFF
--- a/src/result.rs
+++ b/src/result.rs
@@ -54,21 +54,21 @@ impl Error for WebSocketError {
 			WebSocketError::ResponseError(_) => "WebSocket response error",
 			WebSocketError::DataFrameError(_) => "WebSocket data frame error",
 			WebSocketError::NoDataAvailable => "No data available",
-            WebSocketError::IoError(_) => "I/O failure",
-            WebSocketError::HttpError(_) => "HTTP failure",
+			WebSocketError::IoError(_) => "I/O failure",
+			WebSocketError::HttpError(_) => "HTTP failure",
 			WebSocketError::UrlError(_) => "URL failure",
-            WebSocketError::SslError(_) => "SSL failure",
+			WebSocketError::SslError(_) => "SSL failure",
 			WebSocketError::Utf8Error(_) => "UTF-8 failure",
         }
     }
 
     fn cause(&self) -> Option<&Error> {
         match *self {
-			WebSocketError::IoError(ref error) => Some(error as &Error),
-            WebSocketError::HttpError(ref error) => Some(error as &Error),
-			WebSocketError::UrlError(ref error) => Some(error as &Error),
-			WebSocketError::SslError(ref error) => Some(error as &Error),
-			WebSocketError::Utf8Error(ref error) => Some(error as &Error),
+			WebSocketError::IoError(ref error) => Some(error),
+			WebSocketError::HttpError(ref error) => Some(error),
+			WebSocketError::UrlError(ref error) => Some(error),
+			WebSocketError::SslError(ref error) => Some(error),
+			WebSocketError::Utf8Error(ref error) => Some(error),
             _ => None,
         }
     }

--- a/src/result.rs
+++ b/src/result.rs
@@ -47,9 +47,9 @@ impl fmt::Display for WebSocketError {
 }
 
 impl Error for WebSocketError {
-    fn description(&self) -> &str {
-        match *self {
-            WebSocketError::ProtocolError(_) => "WebSocket protocol error",
+	fn description(&self) -> &str {
+		match *self {
+            		WebSocketError::ProtocolError(_) => "WebSocket protocol error",
 			WebSocketError::RequestError(_) => "WebSocket request error",
 			WebSocketError::ResponseError(_) => "WebSocket response error",
 			WebSocketError::DataFrameError(_) => "WebSocket data frame error",
@@ -59,49 +59,49 @@ impl Error for WebSocketError {
 			WebSocketError::UrlError(_) => "URL failure",
 			WebSocketError::SslError(_) => "SSL failure",
 			WebSocketError::Utf8Error(_) => "UTF-8 failure",
-        }
-    }
+		}
+	}
 
-    fn cause(&self) -> Option<&Error> {
-        match *self {
+	fn cause(&self) -> Option<&Error> {
+		match *self {
 			WebSocketError::IoError(ref error) => Some(error),
 			WebSocketError::HttpError(ref error) => Some(error),
 			WebSocketError::UrlError(ref error) => Some(error),
 			WebSocketError::SslError(ref error) => Some(error),
 			WebSocketError::Utf8Error(ref error) => Some(error),
-            _ => None,
-        }
-    }
+			_ => None,
+		}
+	}
 }
 
 impl FromError<io::Error> for WebSocketError {
-    fn from_error(err: io::Error) -> WebSocketError {
-        WebSocketError::IoError(err)
-    }
+	fn from_error(err: io::Error) -> WebSocketError {
+		WebSocketError::IoError(err)
+	}
 }
 
 impl FromError<HttpError> for WebSocketError {
-    fn from_error(err: HttpError) -> WebSocketError {
-        WebSocketError::HttpError(err)
-    }
+	fn from_error(err: HttpError) -> WebSocketError {
+		WebSocketError::HttpError(err)
+	}
 }
 
 impl FromError<ParseError> for WebSocketError {
-    fn from_error(err: ParseError) -> WebSocketError {
-        WebSocketError::UrlError(err)
-    }
+	fn from_error(err: ParseError) -> WebSocketError {
+		WebSocketError::UrlError(err)
+	}
 }
 
 impl FromError<SslError> for WebSocketError {
-    fn from_error(err: SslError) -> WebSocketError {
-        WebSocketError::SslError(err)
-    }
+	fn from_error(err: SslError) -> WebSocketError {
+		WebSocketError::SslError(err)
+	}
 }
 
 impl FromError<Utf8Error> for WebSocketError {
-    fn from_error(err: Utf8Error) -> WebSocketError {
-        WebSocketError::Utf8Error(err)
-    }
+	fn from_error(err: Utf8Error) -> WebSocketError {
+		WebSocketError::Utf8Error(err)
+	}
 }
 
 impl FromError<byteorder::Error> for WebSocketError {


### PR DESCRIPTION
There was a trivial cast warning that should now be fixed. Also, all indentation in src/result.rs has been converted to tabs.