### PR TITLE
Use BufReader in client::Request

### DIFF
--- a/src/client/receiver.rs
+++ b/src/client/receiver.rs
@@ -1,6 +1,8 @@
 //! The default implementation of a WebSocket Receiver.
 
 use std::io::Read;
+use hyper::buffer::BufReader;
+
 use dataframe::{DataFrame, Opcode};
 use result::{WebSocketResult, WebSocketError};
 use ws::util::dataframe::read_dataframe;
@@ -9,24 +11,24 @@ use ws;
 /// A Receiver that wraps a Reader and provides a default implementation using
 /// DataFrames and Messages.
 pub struct Receiver<R> {
-	inner: R,
+	inner: BufReader<R>,
 	buffer: Vec<DataFrame>
 }
 
 impl<R> Receiver<R> {
 	/// Create a new Receiver using the specified Reader.
-	pub fn new(reader: R) -> Receiver<R> {
+	pub fn new(reader: BufReader<R>) -> Receiver<R> {
 		Receiver {
 			inner: reader,
 			buffer: Vec::new()
 		}
 	}
 	/// Returns a reference to the underlying Reader.
-	pub fn get_ref(&self) -> &R {
+	pub fn get_ref(&self) -> &BufReader<R> {
 		&self.inner
 	}
 	/// Returns a mutable reference to the underlying Reader.
-	pub fn get_mut(&mut self) -> &mut R {
+	pub fn get_mut(&mut self) -> &mut BufReader<R> {
 		&mut self.inner
 	}
 }

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -4,6 +4,7 @@ use std::io::{Read, Write};
 pub use url::Url;
 
 use hyper::version::HttpVersion;
+use hyper::buffer::BufReader;
 use hyper::header::Headers;
 use hyper::header::{Connection, ConnectionOption};
 use hyper::header::{Upgrade, Protocol};
@@ -18,7 +19,6 @@ use ws::util::url::url_to_host;
 /// Represents a WebSocket request.
 ///
 /// Note that nothing is written to the internal Writer until the `send()` method is called.
-#[derive(Debug)]
 pub struct Request<R: Read, W: Write> {
 	/// The target URI for this request.
     pub url: Url,
@@ -27,7 +27,7 @@ pub struct Request<R: Read, W: Write> {
 	/// The headers of this request.
 	pub headers: Headers,
 	
-	reader: R,
+	reader: BufReader<R>,
 	writer: W,
 }
 
@@ -56,7 +56,7 @@ impl<R: Read, W: Write> Request<R, W> {
 			url: url,
 			version: HttpVersion::Http11,
 			headers: headers,
-			reader: reader,
+			reader: BufReader::new(reader),
 			writer: writer
 		})
 	}
@@ -116,7 +116,7 @@ impl<R: Read, W: Write> Request<R, W> {
 		self.headers.get_mut()
 	}
 	/// Returns a reference to the inner Reader.
-	pub fn get_reader(&self) -> &R {
+	pub fn get_reader(&self) -> &BufReader<R> {
 		&self.reader
 	}
 	/// Returns a reference to the inner Writer.
@@ -124,7 +124,7 @@ impl<R: Read, W: Write> Request<R, W> {
 		&self.writer
 	}
 	/// Returns a mutable reference to the inner Reader.
-	pub fn get_mut_reader(&mut self) -> &mut R {
+	pub fn get_mut_reader(&mut self) -> &mut BufReader<R> {
 		&mut self.reader
 	}
 	/// Returns a mutable reference to the inner Writer.
@@ -132,7 +132,7 @@ impl<R: Read, W: Write> Request<R, W> {
 		&mut self.writer
 	}
 	/// Return the inner Reader and Writer.
-	pub fn into_inner(self) -> (R, W) {
+	pub fn into_inner(self) -> (BufReader<R>, W) {
 		(self.reader, self.writer)
 	}
 	/// Sends the request to the server and returns a response.

--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -2,8 +2,8 @@
 use std::option::Option;
 use std::io::{Read, Write};
 
-use hyper::buffer::BufReader;
 use hyper::status::StatusCode;
+use hyper::buffer::BufReader;
 use hyper::version::HttpVersion;
 use hyper::header::Headers;
 use hyper::header::{Connection, ConnectionOption};
@@ -20,7 +20,6 @@ use dataframe::DataFrame;
 use ws;
 
 /// Represents a WebSocket response.
-#[derive(Debug)]
 pub struct Response<R: Read, W: Write> {
 	/// The status of the response
 	pub status: StatusCode,
@@ -40,14 +39,14 @@ impl<R: Read, W: Write> Response<R, W> {
 	/// This is called by Request.send(), and does not need to be called by the user.
 	pub fn read(mut request: Request<R, W>) -> WebSocketResult<Response<R, W>> {
 		let (status, version, headers) = {
-			let mut reader = BufReader::new(request.get_mut_reader());
+			let reader = request.get_mut_reader();
 			
-			let response = try!(parse_response(&mut reader));
+			let response = try!(parse_response(reader));
 			
 			let status = StatusCode::from_u16(response.subject.0);
 			(status, response.version, response.headers)
 		};
-		
+
 		Ok(Response {
 			status: status,
 			headers: headers,
@@ -69,7 +68,7 @@ impl<R: Read, W: Write> Response<R, W> {
 		self.headers.get()
 	}
 		/// Returns a reference to the inner Reader.
-	pub fn get_reader(&self) -> &R {
+	pub fn get_reader(&self) -> &BufReader<R> {
 		self.request.get_reader()
 	}
 	/// Returns a reference to the inner Writer.
@@ -77,7 +76,7 @@ impl<R: Read, W: Write> Response<R, W> {
 		self.request.get_writer()
 	}
 	/// Returns a mutable reference to the inner Reader.
-	pub fn get_mut_reader(&mut self) -> &mut R {
+	pub fn get_mut_reader(&mut self) -> &mut BufReader<R> {
 		self.request.get_mut_reader()
 	}
 	/// Returns a mutable reference to the inner Writer.
@@ -89,7 +88,7 @@ impl<R: Read, W: Write> Response<R, W> {
 		&self.request
 	}
 	/// Return the inner Reader and Writer.
-	pub fn into_inner(self) -> (R, W) {
+	pub fn into_inner(self) -> (BufReader<R>, W) {
 		self.request.into_inner()
 	}
 	


### PR DESCRIPTION
This should fix the failing autobahn tests for the client. There might be a better way of doing this?