### PR TITLE
update to Hyper 0.4.0

### DIFF
--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -7,7 +7,7 @@ use hyper::version::HttpVersion;
 use hyper::buffer::BufReader;
 use hyper::header::Headers;
 use hyper::header::{Connection, ConnectionOption};
-use hyper::header::{Upgrade, Protocol};
+use hyper::header::{Upgrade, Protocol, ProtocolName};
 
 use unicase::UniCase;
 
@@ -48,7 +48,10 @@ impl<R: Read, W: Write> Request<R, W> {
 		headers.set(Connection(vec![
 			ConnectionOption::ConnectionHeader(UniCase("Upgrade".to_string()))
 		]));
-		headers.set(Upgrade(vec![Protocol::WebSocket]));
+		headers.set(Upgrade(vec![Protocol{
+			name: ProtocolName::WebSocket,
+			version: None
+		}]));
 		headers.set(WebSocketVersion::WebSocket13);
 		headers.set(WebSocketKey::new());
 		

--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -7,7 +7,7 @@ use hyper::buffer::BufReader;
 use hyper::version::HttpVersion;
 use hyper::header::Headers;
 use hyper::header::{Connection, ConnectionOption};
-use hyper::header::{Upgrade, Protocol};
+use hyper::header::{Upgrade, Protocol, ProtocolName};
 use hyper::http::parse_response;
 
 use unicase::UniCase;
@@ -103,7 +103,10 @@ impl<R: Read, W: Write> Response<R, W> {
 		if self.accept() != Some(&(WebSocketAccept::new(key))) {
 			return Err(WebSocketError::ResponseError("Sec-WebSocket-Accept is invalid".to_string()));
 		}
-		if self.headers.get() != Some(&(Upgrade(vec![Protocol::WebSocket]))) {
+		if self.headers.get() != Some(&(Upgrade(vec![Protocol{
+			name: ProtocolName::WebSocket,
+			version: None
+		}]))) {
 			return Err(WebSocketError::ResponseError("Upgrade field must be WebSocket".to_string()));
 		}
 		if self.headers.get() != Some(&(Connection(vec![ConnectionOption::ConnectionHeader(UniCase("Upgrade".to_string()))]))) {

--- a/src/result.rs
+++ b/src/result.rs
@@ -6,7 +6,7 @@ use std::error::Error;
 use std::convert::From;
 use std::fmt;
 use openssl::ssl::error::SslError;
-use hyper::HttpError;
+use hyper::Error as HttpError;
 use url::ParseError;
 use byteorder;
 


### PR DESCRIPTION
rust-websocket is currently broken since hyper upgraded to 0.4.0.

I attempted to fix the issues, but now I am getting an ICE on the latest rust nightly build.

```
rustc --version
rustc 1.1.0-nightly (7bd71637c 2015-05-06) (built 2015-05-06)
```