### PR TITLE
Postpone some to_string calls to happen only during an error

### DIFF
--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -98,9 +98,9 @@ impl<R: Read, W: Write> Response<R, W> {
 		if self.status != StatusCode::SwitchingProtocols {
 			return Err(WebSocketError::ResponseError("Status code must be Switching Protocols".to_string()));
 		}
-		let key = try!(self.request.key().ok_or(
+		let key = try!(self.request.key().ok_or_else(|| {
 			WebSocketError::RequestError("Request Sec-WebSocket-Key was invalid".to_string())
-		));
+		}));
 		if self.accept() != Some(&(WebSocketAccept::new(key))) {
 			return Err(WebSocketError::ResponseError("Sec-WebSocket-Accept is invalid".to_string()));
 		}

--- a/src/message.rs
+++ b/src/message.rs
@@ -162,9 +162,9 @@ impl<'a, 'b> ws::Message<'b, &'b Message<'a>> for Message<'a> {
 	/// Attempt to form a message from a series of data frames
 	fn from_dataframes<D>(frames: Vec<D>) -> WebSocketResult<Self>
     where D: ws::dataframe::DataFrame {
-		let opcode = try!(frames.first().ok_or(WebSocketError::ProtocolError(
-			"No dataframes provided".to_string()
-		)).map(|d| d.opcode()));
+		let opcode = try!(frames.first().ok_or_else(|| {
+			WebSocketError::ProtocolError("No dataframes provided".to_string())
+		}).map(|d| d.opcode()));
 
 		let mut data = Vec::new();
 


### PR DESCRIPTION
### Tooo many `to_string()`s
Hey again! Just wanted to add a small tweak, I noticed sometimes a string gets made describing an error even when there is no error! This is expensive and should be stopped!

I haven't noticed any error description that isn't a `&'static str`, maybe all the errors should just  use that instead of `String`.