### PR TITLE
this PR comes with questions

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -2,6 +2,7 @@
 
 use std::net::TcpStream;
 use std::marker::PhantomData;
+use std::io::Result as IoResult;
 
 use ws;
 use ws::util::url::ToWebSocketUrlComponents;
@@ -96,6 +97,24 @@ impl Client<DataFrame, Sender<WebSocketStream>, Receiver<WebSocketStream>> {
 
 		Request::new((host, resource_name, secure), try!(stream.try_clone()), stream)
 	}
+
+    /// Shuts down the sending half of the client connection, will cause all pending
+    /// and future IO to return immediately with an appropriate value.
+    pub fn shutdown_sender(&mut self) -> IoResult<()> {
+        self.sender.shutdown()
+    }
+
+    /// Shuts down the receiving half of the client connection, will cause all pending
+    /// and future IO to return immediately with an appropriate value.
+    pub fn shutdown_receiver(&mut self) -> IoResult<()> {
+        self.receiver.shutdown()
+    }
+
+    /// Shuts down the client connection, will cause all pending and future IO to
+    /// return immediately with an appropriate value.
+    pub fn shutdown(&mut self) -> IoResult<()> {
+        self.receiver.shutdown_all()
+    }
 }
 
 impl<F: DataFrameable, S: ws::Sender, R: ws::Receiver<F>> Client<F, S, R> {

--- a/src/client/receiver.rs
+++ b/src/client/receiver.rs
@@ -1,10 +1,13 @@
 //! The default implementation of a WebSocket Receiver.
 
 use std::io::Read;
+use std::io::Result as IoResult;
 use hyper::buffer::BufReader;
 
 use dataframe::{DataFrame, Opcode};
 use result::{WebSocketResult, WebSocketError};
+use stream::WebSocketStream;
+use stream::Shutdown;
 use ws;
 
 /// A Receiver that wraps a Reader and provides a default implementation using
@@ -30,6 +33,20 @@ impl<R> Receiver<R> {
 	pub fn get_mut(&mut self) -> &mut BufReader<R> {
 		&mut self.inner
 	}
+}
+
+impl Receiver<WebSocketStream> {
+    /// Closes the receiver side of the connection, will cause all pending and future IO to
+    /// return immediately with an appropriate value.
+    pub fn shutdown(&mut self) -> IoResult<()> {
+        self.inner.get_mut().shutdown(Shutdown::Read)
+    }
+
+    /// Shuts down both Sender and Receiver, will cause all pending and future IO to
+    /// return immediately with an appropriate value.
+    pub fn shutdown_all(&mut self) -> IoResult<()> {
+        self.inner.get_mut().shutdown(Shutdown::Both)
+    }
 }
 
 impl<R: Read> ws::Receiver<DataFrame> for Receiver<R> {

--- a/src/client/sender.rs
+++ b/src/client/sender.rs
@@ -1,8 +1,11 @@
 //! The default implementation of a WebSocket Sender.
 
 use std::io::Write;
+use std::io::Result as IoResult;
 use result::WebSocketResult;
 use ws::dataframe::DataFrame;
+use stream::WebSocketStream;
+use stream::Shutdown;
 use ws;
 
 /// A Sender that wraps a Writer and provides a default implementation using
@@ -26,6 +29,20 @@ impl<W> Sender<W> {
 	pub fn get_mut(&mut self) -> &mut W {
 		&mut self.inner
 	}
+}
+
+impl Sender<WebSocketStream> {
+    /// Closes the sender side of the connection, will cause all pending and future IO to
+    /// return immediately with an appropriate value.
+    pub fn shutdown(&mut self) -> IoResult<()> {
+        self.inner.shutdown(Shutdown::Write)
+    }
+
+    /// Shuts down both Sender and Receiver, will cause all pending and future IO to
+    /// return immediately with an appropriate value.
+    pub fn shutdown_all(&mut self) -> IoResult<()> {
+        self.inner.shutdown(Shutdown::Both)
+    }
 }
 
 impl<W: Write> ws::Sender for Sender<W> {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,5 +1,6 @@
 //! Provides an implementation of a WebSocket server
 use std::net::{SocketAddr, ToSocketAddrs, TcpListener};
+use std::net::Shutdown;
 use std::io::{Read, Write};
 use std::io;
 pub use self::request::Request;
@@ -152,4 +153,13 @@ impl<R: Read, W: Write> Connection<R, W> {
 			}
 		}
 	}
+}
+
+impl Connection<WebSocketStream, WebSocketStream> {
+    /// Shuts down the currennt connection in the specified way.
+    /// All future IO calls to this connection will return immediately with an appropriate
+    /// return value.
+    pub fn shutdown(&mut self, how: Shutdown) -> io::Result<()> {
+        self.0.shutdown(how)
+    }
 }

--- a/src/server/receiver.rs
+++ b/src/server/receiver.rs
@@ -1,7 +1,10 @@
 //! The default implementation of a WebSocket Receiver.
 
 use std::io::Read;
+use std::io::Result as IoResult;
 use dataframe::{DataFrame, Opcode};
+use stream::WebSocketStream;
+use stream::Shutdown;
 use result::{WebSocketResult, WebSocketError};
 use ws;
 
@@ -28,6 +31,20 @@ impl<R> Receiver<R> {
 	pub fn get_mut(&mut self) -> &mut R {
 		&mut self.inner
 	}
+}
+
+impl Receiver<WebSocketStream> {
+    /// Closes the receiver side of the connection, will cause all pending and future IO to
+    /// return immediately with an appropriate value.
+    pub fn shutdown(&mut self) -> IoResult<()> {
+        self.inner.shutdown(Shutdown::Read)
+    }
+
+    /// Shuts down both Sender and Receiver, will cause all pending and future IO to
+    /// return immediately with an appropriate value.
+    pub fn shutdown_all(&mut self) -> IoResult<()> {
+        self.inner.shutdown(Shutdown::Both)
+    }
 }
 
 impl<R: Read> ws::Receiver<DataFrame> for Receiver<R> {

--- a/src/server/sender.rs
+++ b/src/server/sender.rs
@@ -1,7 +1,10 @@
 //! The default implementation of a WebSocket Sender.
 
 use std::io::Write;
+use std::io::Result as IoResult;
 use ws::dataframe::DataFrame;
+use stream::WebSocketStream;
+use stream::Shutdown;
 use result::WebSocketResult;
 use ws;
 
@@ -26,6 +29,20 @@ impl<W> Sender<W> {
 	pub fn get_mut(&mut self) -> &mut W {
 		&mut self.inner
 	}
+}
+
+impl Sender<WebSocketStream> {
+    /// Closes the sender side of the connection, will cause all pending and future IO to
+    /// return immediately with an appropriate value.
+    pub fn shutdown(&mut self) -> IoResult<()> {
+        self.inner.shutdown(Shutdown::Write)
+    }
+
+    /// Shuts down both Sender and Receiver, will cause all pending and future IO to
+    /// return immediately with an appropriate value.
+    pub fn shutdown_all(&mut self) -> IoResult<()> {
+        self.inner.shutdown(Shutdown::Both)
+    }
 }
 
 impl<W: Write> ws::Sender for Sender<W> {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -2,9 +2,10 @@
 extern crate net2;
 
 use std::io::{self, Read, Write};
-use std::net::{SocketAddr, Shutdown, TcpStream};
 use self::net2::TcpStreamExt;
 use openssl::ssl::SslStream;
+
+pub use std::net::{SocketAddr, Shutdown, TcpStream};
 
 /// A useful stream type for carrying WebSocket connections.
 pub enum WebSocketStream {


### PR DESCRIPTION
While fixing #28, I though of a few questions:

1. What is the point of having different client & server implementations of receiver & sender?
2. Would it make more sense if the server gave out a `Client` on a new connection?
3. I would like to use this library with mio, I'm working on putting this under a feature [here](https://github.com/illegalprime/rust-websocket/tree/mio). Do you think this is a good idea?
4. Maybe this library is better off parting with `hyper` since its such a giant library? I think I see it used for only headers.
5. What is the point of having different client & server implementations of request & response?

I ask because there is a rust websocket library claiming to be lightweight, and I want this one to be the main library. There is also one that boasts to support mio. (Also I want to use mio) 
