### PR TITLE
send BufReader instead of stream to reciever

### DIFF
--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -130,7 +130,7 @@ impl<R: Read, W: Write> Response<R, W> {
 	pub fn begin(self) -> Client<DataFrame, Sender<W>, Receiver<R>> {
 		let (reader, writer) = self.into_inner();
 		let sender = Sender::new(writer, true);
-		let receiver = Receiver::new(reader.into_inner(), false);
+		let receiver = Receiver::new(reader, false);
 		Client::new(sender, receiver)
 	}
 }

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -21,9 +21,9 @@ pub struct Receiver<R> {
 impl<R> Receiver<R>
 where R: Read {
 	/// Create a new Receiver using the specified Reader.
-	pub fn new(reader: R, mask: bool) -> Receiver<R> {
+	pub fn new(reader: BufReader<R>, mask: bool) -> Receiver<R> {
 		Receiver {
-			inner: BufReader::new(reader),
+			inner: reader,
 			buffer: Vec::new(),
 			mask: mask,
 		}

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -6,6 +6,7 @@ use hyper::version::HttpVersion;
 use hyper::header::Headers;
 use hyper::header::{Connection, ConnectionOption};
 use hyper::header::{Upgrade, Protocol, ProtocolName};
+use hyper::buffer::BufReader;
 
 use unicase::UniCase;
 
@@ -143,7 +144,7 @@ impl<R: Read, W: Write> Response<R, W> {
 		try!(write!(self.get_mut_writer(), "{}\r\n", headers));
 		let (reader, writer) = self.into_inner();
 		let sender = Sender::new(writer, false);
-		let receiver = Receiver::new(reader, true);
+		let receiver = Receiver::new(BufReader::new(reader), true);
 		Ok(Client::new(sender, receiver))
 	}
 }


### PR DESCRIPTION
Fix issue where first websocket messages can be consumed during
handshake and never sent to server.

Fix for #72