### PR TITLE
Adding ability to accept connections and receive messages without blocking.

### DIFF
--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -50,6 +50,14 @@ impl Receiver<WebSocketStream> {
     pub fn shutdown_all(&mut self) -> IoResult<()> {
         self.inner.get_mut().shutdown(Shutdown::Both)
     }
+
+    /// Changes whether the receiver is in nonblocking mode.
+    ///
+    /// If it is in nonblocking mode and there is no incoming message, trying to receive a message
+    /// will return an error instead of blocking.
+    pub fn set_nonblocking(&self, nonblocking: bool) -> IoResult<()> {
+        self.inner.get_ref().set_nonblocking(nonblocking)
+    }
 }
 
 impl<R: Read> ws::Receiver<DataFrame> for Receiver<R> {

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -45,6 +45,11 @@ impl Sender<WebSocketStream> {
     pub fn shutdown_all(&mut self) -> IoResult<()> {
         self.inner.shutdown(Shutdown::Both)
     }
+
+    /// Changes whether the sender is in nonblocking mode.
+    pub fn set_nonblocking(&self, nonblocking: bool) -> IoResult<()> {
+        self.inner.set_nonblocking(nonblocking)
+    }
 }
 
 impl<W: Write> ws::Sender for Sender<W> {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -126,6 +126,14 @@ impl<'a> Server<'a> {
 		};
 		Ok(Connection(try!(wsstream.try_clone()), try!(wsstream.try_clone())))
 	}
+
+    /// Changes whether the Server is in nonblocking mode.
+    ///
+    /// If it is in nonblocking mode, accept() will return an error instead of blocking when there
+    /// are no incoming connections.
+    pub fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
+        self.inner.set_nonblocking(nonblocking)
+    }
 }
 
 impl<'a> Iterator for Server<'a> {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -83,4 +83,12 @@ impl WebSocketStream {
 			WebSocketStream::Ssl(ref inner) => WebSocketStream::Ssl(try!(inner.try_clone())),
 		})
 	}
+
+    /// Changes whether the stream is in nonblocking mode.
+    pub fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
+        match *self {
+			WebSocketStream::Tcp(ref inner) => inner.set_nonblocking(nonblocking),
+			WebSocketStream::Ssl(ref inner) => inner.get_ref().set_nonblocking(nonblocking),
+        }
+    }
 }


### PR DESCRIPTION
This has to do with: https://github.com/cyderize/rust-websocket/issues/81

I added a `set_nonblocking` method to the `Server` so it is possible to make accepting connections not block, and added a `set_nonblocking` method to `Receiver<WebSocketStream>` so it is possible to make receiving messages not block.

Documentation, examples and tests still need to be written.