### PR TITLE
Make openssl optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ bitflags = "0.7"
 rand = "0.3.12"
 byteorder = "0.5.1"
 net2 = "0.2.17"
+sha1 = "0.2.0"
 
 [features]
 nightly = ["hyper/nightly"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ keywords = ["websocket", "websockets", "rfc6455"]
 license = "MIT"
 
 [dependencies]
-hyper = ">=0.7, <0.10"
+hyper = { version = ">=0.7, <0.10", default-features=false }
 unicase = "1.0.1"
-openssl = "0.7.6"
+openssl = { version = "0.7.6", optional=true }
 url = "1.0"
 rustc-serialize = "0.3.16"
 bitflags = "0.7"
@@ -29,4 +29,6 @@ net2 = "0.2.17"
 sha1 = "0.2.0"
 
 [features]
+default = ["ssl"]
 nightly = ["hyper/nightly"]
+ssl = ["openssl", "hyper/ssl"]

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -2,7 +2,7 @@ extern crate websocket;
 
 fn main() {
 	use std::thread;
-	use std::sync::mpsc::channel;
+	use std::sync::mpsc::sync_channel;
 	use std::io::stdin;
 
 	use websocket::{Message, Sender, Receiver};
@@ -26,7 +26,7 @@ fn main() {
 
 	let (mut sender, mut receiver) = response.begin().split();
 
-	let (tx, rx) = channel();
+	let (tx, rx) = sync_channel(10);
 
 	let tx_1 = tx.clone();
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -34,8 +34,8 @@ fn main() {
 
 			println!("Connection from {}", ip);
 
-			let message: Message = Message::text("Hello".to_string());
-			client.send_message(&message).unwrap();
+			//let message: Message = Message::text("Hello".to_string());
+			//client.send_message(&message).unwrap();
 
 			let (mut sender, mut receiver) = client.split();
 

--- a/src/header/accept.rs
+++ b/src/header/accept.rs
@@ -5,7 +5,7 @@ use std::fmt::{self, Debug};
 use std::str::FromStr;
 use serialize::base64::{ToBase64, FromBase64, STANDARD};
 use header::WebSocketKey;
-use openssl::crypto::hash::{self, hash};
+use sha1::Sha1;
 use result::{WebSocketResult, WebSocketError};
 
 static MAGIC_GUID: &'static str = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
@@ -54,12 +54,9 @@ impl WebSocketAccept {
 		let mut concat_key = String::with_capacity(serialized.len() + 36);
 		concat_key.push_str(&serialized[..]);
 		concat_key.push_str(MAGIC_GUID);
-		let output = hash(hash::Type::SHA1, concat_key.as_bytes());
-		let mut iter = output.into_iter();
-		let mut bytes = [0u8; 20];
-		for i in bytes.iter_mut() {
-			*i = iter.next().unwrap();
-		}
+		let mut sha1 = Sha1::new();
+		sha1.update(concat_key.as_bytes());
+		let bytes = sha1.digest().bytes();
 		WebSocketAccept(bytes)
 	}
 	/// Return the Base64 encoding of this WebSocketAccept

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ extern crate hyper;
 extern crate unicase;
 extern crate url;
 extern crate rustc_serialize as serialize;
+#[cfg(feature="ssl")]
 extern crate openssl;
 extern crate rand;
 extern crate byteorder;
@@ -69,3 +70,8 @@ pub mod stream;
 pub mod header;
 pub mod receiver;
 pub mod sender;
+
+#[cfg(not(feature="ssl"))]
+mod openssl { pub mod ssl {
+    pub struct SslContext;
+}}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ extern crate rustc_serialize as serialize;
 extern crate openssl;
 extern crate rand;
 extern crate byteorder;
+extern crate sha1;
 
 #[macro_use]
 extern crate bitflags;

--- a/src/result.rs
+++ b/src/result.rs
@@ -5,6 +5,7 @@ use std::str::Utf8Error;
 use std::error::Error;
 use std::convert::From;
 use std::fmt;
+#[cfg(feature="ssl")]
 use openssl::ssl::error::SslError;
 use hyper::Error as HttpError;
 use url::ParseError;
@@ -34,7 +35,11 @@ pub enum WebSocketError {
     /// A WebSocket URL error
     WebSocketUrlError(WSUrlErrorKind),
 	/// An SSL error
+	#[cfg(feature="ssl")]
 	SslError(SslError),
+	/// An error when user tries wss:// when SSL feature is not enabled
+	#[cfg(not(feature="ssl"))]
+	SslFeatureNotEnabled,
 	/// A UTF-8 error
 	Utf8Error(Utf8Error),
 }
@@ -58,7 +63,10 @@ impl Error for WebSocketError {
 			WebSocketError::IoError(_) => "I/O failure",
 			WebSocketError::HttpError(_) => "HTTP failure",
 			WebSocketError::UrlError(_) => "URL failure",
+			#[cfg(feature="ssl")]
 			WebSocketError::SslError(_) => "SSL failure",
+			#[cfg(not(feature="ssl"))]
+			WebSocketError::SslFeatureNotEnabled => "SSL feature not enabled",
 			WebSocketError::Utf8Error(_) => "UTF-8 failure",
             WebSocketError::WebSocketUrlError(_) => "WebSocket URL failure",
 		}
@@ -69,7 +77,10 @@ impl Error for WebSocketError {
 			WebSocketError::IoError(ref error) => Some(error),
 			WebSocketError::HttpError(ref error) => Some(error),
 			WebSocketError::UrlError(ref error) => Some(error),
+			#[cfg(feature="ssl")]
 			WebSocketError::SslError(ref error) => Some(error),
+			#[cfg(not(feature="ssl"))]
+			WebSocketError::SslFeatureNotEnabled => None,
 			WebSocketError::Utf8Error(ref error) => Some(error),
             WebSocketError::WebSocketUrlError(ref error) => Some(error),
 			_ => None,
@@ -98,6 +109,7 @@ impl From<ParseError> for WebSocketError {
 	}
 }
 
+#[cfg(feature="ssl")]
 impl From<SslError> for WebSocketError {
 	fn from(err: SslError) -> WebSocketError {
 		WebSocketError::SslError(err)

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -3,6 +3,7 @@ extern crate net2;
 
 use std::io::{self, Read, Write};
 use self::net2::TcpStreamExt;
+#[cfg(feature="ssl")]
 use openssl::ssl::SslStream;
 
 pub use std::net::{SocketAddr, Shutdown, TcpStream};
@@ -12,6 +13,7 @@ pub enum WebSocketStream {
 	/// A TCP stream.
 	Tcp(TcpStream),
 	/// An SSL-backed TCP Stream
+	#[cfg(feature="ssl")]
 	Ssl(SslStream<TcpStream>)
 }
 
@@ -19,6 +21,7 @@ impl Read for WebSocketStream {
 	fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
 		match *self {
 		WebSocketStream::Tcp(ref mut inner) => inner.read(buf),
+			#[cfg(feature="ssl")]
 			WebSocketStream::Ssl(ref mut inner) => inner.read(buf),
 		}
 	}
@@ -28,6 +31,7 @@ impl Write for WebSocketStream {
 	fn write(&mut self, msg: &[u8]) -> io::Result<usize> {
 		match *self {
 			WebSocketStream::Tcp(ref mut inner) => inner.write(msg),
+			#[cfg(feature="ssl")]
 			WebSocketStream::Ssl(ref mut inner) => inner.write(msg),
 		}
 	}
@@ -35,6 +39,7 @@ impl Write for WebSocketStream {
 	fn flush(&mut self) -> io::Result<()> {
 		match *self {
 			WebSocketStream::Tcp(ref mut inner) => inner.flush(),
+			#[cfg(feature="ssl")]
 			WebSocketStream::Ssl(ref mut inner) => inner.flush(),
 		}
 	}
@@ -45,6 +50,7 @@ impl WebSocketStream {
 	pub fn peer_addr(&self) -> io::Result<SocketAddr> {
 		match *self {
 			WebSocketStream::Tcp(ref inner) => inner.peer_addr(),
+			#[cfg(feature="ssl")]
 			WebSocketStream::Ssl(ref inner) => inner.get_ref().peer_addr(),
 		}
 	}
@@ -52,6 +58,7 @@ impl WebSocketStream {
 	pub fn local_addr(&self) -> io::Result<SocketAddr> {
 		match *self {
 			WebSocketStream::Tcp(ref inner) => inner.local_addr(),
+			#[cfg(feature="ssl")]
 			WebSocketStream::Ssl(ref inner) => inner.get_ref().local_addr(),
 		}
 	}
@@ -59,6 +66,7 @@ impl WebSocketStream {
 	pub fn set_nodelay(&mut self, nodelay: bool) -> io::Result<()> {
 		match *self {
 			WebSocketStream::Tcp(ref mut inner) => TcpStreamExt::set_nodelay(inner, nodelay),
+			#[cfg(feature="ssl")]
 			WebSocketStream::Ssl(ref mut inner) => TcpStreamExt::set_nodelay(inner.get_mut(), nodelay),
 		}
 	}
@@ -66,6 +74,7 @@ impl WebSocketStream {
 	pub fn set_keepalive(&mut self, delay_in_ms: Option<u32>) -> io::Result<()> {
 		match *self {
 			WebSocketStream::Tcp(ref mut inner) => TcpStreamExt::set_keepalive_ms(inner, delay_in_ms),
+			#[cfg(feature="ssl")]
 			WebSocketStream::Ssl(ref mut inner) => TcpStreamExt::set_keepalive_ms(inner.get_mut(), delay_in_ms),
 		}
 	}
@@ -73,6 +82,7 @@ impl WebSocketStream {
 	pub fn shutdown(&mut self, shutdown: Shutdown) -> io::Result<()> {
 		match *self {
 			WebSocketStream::Tcp(ref mut inner) => inner.shutdown(shutdown),
+			#[cfg(feature="ssl")]
 			WebSocketStream::Ssl(ref mut inner) => inner.get_mut().shutdown(shutdown),
 		}
 	}
@@ -80,6 +90,7 @@ impl WebSocketStream {
 	pub fn try_clone(&self) -> io::Result<WebSocketStream> {
 		Ok(match *self {
 			WebSocketStream::Tcp(ref inner) => WebSocketStream::Tcp(try!(inner.try_clone())),
+			#[cfg(feature="ssl")]
 			WebSocketStream::Ssl(ref inner) => WebSocketStream::Ssl(try!(inner.try_clone())),
 		})
 	}
@@ -88,6 +99,7 @@ impl WebSocketStream {
     pub fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
         match *self {
 			WebSocketStream::Tcp(ref inner) => inner.set_nonblocking(nonblocking),
+			#[cfg(feature="ssl")]
 			WebSocketStream::Ssl(ref inner) => inner.get_ref().set_nonblocking(nonblocking),
         }
     }


### PR DESCRIPTION
Hacks:
    
* Dummy SslContext
* Trickery in secure server doctest
* Sha1 used from other crate instead of openssl (even openssl enabled)
