### PR TITLE
Open access to server::Connection fields

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -145,7 +145,7 @@ impl<'a> Iterator for Server<'a> {
 }
 
 /// Represents a connection to the server that has not been processed yet.
-pub struct Connection<R: Read, W: Write>(R, W);
+pub struct Connection<R: Read, W: Write>(pub R, pub W);
 
 impl<R: Read, W: Write> Connection<R, W> {
 	/// Process this connection and read the request.


### PR DESCRIPTION
Allow users to make custom servers (non-TCP, non-SSL).
For example, UNIX-socket-based server for Nginx integration.