### PR TITLE
Upgrade openssl dependency to 0.9.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ keywords = ["websocket", "websockets", "rfc6455"]
 license = "MIT"
 
 [dependencies]
-hyper = ">=0.7, <0.10"
+hyper = "0.10.5"
 unicase = "1.0.1"
-openssl = "0.7.6"
+openssl = "0.9.7"
 url = "1.0"
 rustc-serialize = "0.3.16"
 bitflags = "0.7"

--- a/examples/hyper.rs
+++ b/examples/hyper.rs
@@ -7,7 +7,6 @@ use websocket::{Server, Message, Sender, Receiver};
 use websocket::header::WebSocketProtocol;
 use websocket::message::Type;
 use hyper::Server as HttpServer;
-use hyper::server::Handler;
 use hyper::net::Fresh;
 use hyper::server::request::Request;
 use hyper::server::response::Response;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -12,7 +12,7 @@ use stream::WebSocketStream;
 use dataframe::DataFrame;
 use ws::dataframe::DataFrame as DataFrameable;
 
-use openssl::ssl::{SslContext, SslMethod, SslStream};
+use openssl::ssl::{SslContext, SslContextBuilder, Ssl, SslMethod};
 
 pub use self::request::Request;
 pub use self::response::Response;
@@ -68,7 +68,7 @@ impl Client<DataFrame, Sender<WebSocketStream>, Receiver<WebSocketStream>> {
 	/// A connection is established, however the request is not sent to
 	/// the server until a call to ```send()```.
 	pub fn connect<T: ToWebSocketUrlComponents>(components: T) -> WebSocketResult<Request<WebSocketStream, WebSocketStream>> {
-		let context = try!(SslContext::new(SslMethod::Tlsv1));
+		let context = SslContextBuilder::new(SslMethod::tls())?.build();
 		Client::connect_ssl_context(components, &context)
 	}
 	/// Connects to the specified wss:// URL using the given SSL context.
@@ -86,7 +86,7 @@ impl Client<DataFrame, Sender<WebSocketStream>, Receiver<WebSocketStream>> {
 		));
 
 		let stream = if secure {
-			let sslstream = try!(SslStream::connect(context, connection));
+			let sslstream = Ssl::new(context)?.connect(connection)?;
 			WebSocketStream::Ssl(sslstream)
 		}
 		else {

--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -101,7 +101,7 @@ impl<R: Read, W: Write> Response<R, W> {
 		let key = try!(self.request.key().ok_or(
 			WebSocketError::RequestError("Request Sec-WebSocket-Key was invalid")
 		));
-		if self.accept() != Some(&(WebSocketAccept::new(key))) {
+		if self.accept() != Some(&(WebSocketAccept::new(key)?)) {
 			return Err(WebSocketError::ResponseError("Sec-WebSocket-Accept is invalid"));
 		}
 		if self.headers.get() != Some(&(Upgrade(vec![Protocol{

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -8,8 +8,7 @@ pub use self::response::Response;
 
 use stream::WebSocketStream;
 
-use openssl::ssl::SslContext;
-use openssl::ssl::SslStream;
+use openssl::ssl::{SslContext, Ssl};
 
 pub mod request;
 pub mod response;
@@ -52,13 +51,14 @@ pub mod response;
 ///use std::thread;
 ///use std::path::Path;
 ///use websocket::{Server, Message};
-///use openssl::ssl::{SslContext, SslMethod};
-///use openssl::x509::X509FileType;
+///use openssl::ssl::{Ssl, SslContext, SslContextBuilder, SslMethod};
+///use openssl::x509::X509_FILETYPE_PEM;
 ///
-///let mut context = SslContext::new(SslMethod::Tlsv1).unwrap();
-///let _ = context.set_certificate_file(&(Path::new("cert.pem")), X509FileType::PEM);
-///let _ = context.set_private_key_file(&(Path::new("key.pem")), X509FileType::PEM);
-///let server = Server::bind_secure("127.0.0.1:1234", &context).unwrap();
+///let mut builder = SslContextBuilder::new(SslMethod::tls()).unwrap();
+///let _ = builder.set_certificate_file(&(Path::new("cert.pem")), X509_FILETYPE_PEM);
+///let _ = builder.set_private_key_file(&(Path::new("key.pem")), X509_FILETYPE_PEM);
+///let ctx = builder.build();
+///let server = Server::bind_secure("127.0.0.1:1234", &ctx).unwrap();
 ///
 ///for connection in server {
 ///    // Spawn a new thread for each connection.
@@ -114,7 +114,7 @@ impl<'a> Server<'a> {
 		let stream = try!(self.inner.accept()).0;
 		let wsstream = match self.context {
 			Some(context) => {
-				let sslstream = match SslStream::accept(context, stream) {
+				let sslstream = match Ssl::new(context)?.accept(stream) {
 					Ok(s) => s,
 					Err(err) => {
 						return Err(io::Error::new(io::ErrorKind::Other, err));

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -74,7 +74,7 @@ impl<R: Read, W: Write> Response<R, W> {
 	/// Create a new outbound WebSocket response.
 	pub fn new(request: Request<R, W>) -> Response<R, W> {
 		let mut headers = Headers::new();
-		headers.set(WebSocketAccept::new(request.key().unwrap()));
+		headers.set(WebSocketAccept::new(request.key().unwrap()).unwrap());
 		headers.set(Connection(vec![
 			ConnectionOption::ConnectionHeader(UniCase("Upgrade".to_string()))
 		]));

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -80,7 +80,8 @@ impl WebSocketStream {
 	pub fn try_clone(&self) -> io::Result<WebSocketStream> {
 		Ok(match *self {
 			WebSocketStream::Tcp(ref inner) => WebSocketStream::Tcp(try!(inner.try_clone())),
-			WebSocketStream::Ssl(ref inner) => WebSocketStream::Ssl(try!(inner.try_clone())),
+			// FIXME: This is **terrible**! But SslStream no longer has try_clone...
+			WebSocketStream::Ssl(ref inner) => WebSocketStream::Tcp(try!(inner.get_ref().try_clone())),
 		})
 	}
 


### PR DESCRIPTION
I'd like to upgrade the openssl dependency to the latest, to allow rust-websocket to be used alongside other crates which also depend on openssl. The upgrade was mostly straightforward, but I did hit one snag: `SslStream` no longer implements `try_clone`, which makes implementing it for `WebSocketStream` problematic. Apparently rustls' `ClientSession` also doesn't provide a `try_clone`.

**This PR breaks secure websockets**; I'm not suggesting you merge it as-is - just asking for suggestions.