### PR TITLE
removed rust serialize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,15 @@ license = "MIT"
 hyper = "^0.10.6"
 unicase = "^1.0"
 url = "^1.0"
-rustc-serialize = "^0.3"
 bitflags = "^0.8"
 rand = "^0.3"
 byteorder = "^1.0"
 sha1 = "^0.2"
 openssl = { version = "^0.9.10", optional = true }
+base64 = "^0.5"
+
+[dev-dependencies]
+serde_json = "^1.0"
 
 [features]
 default = ["ssl"]

--- a/examples/autobahn-client.rs
+++ b/examples/autobahn-client.rs
@@ -1,11 +1,10 @@
 extern crate websocket;
-extern crate rustc_serialize as serialize;
+extern crate serde_json;
 
 use std::str::from_utf8;
 use websocket::ClientBuilder;
 use websocket::Message;
 use websocket::message::Type;
-use serialize::json;
 
 fn main() {
 	let addr = "ws://127.0.0.1:9001".to_string();
@@ -93,7 +92,7 @@ fn get_case_count(addr: String) -> usize {
 		};
 		match message.opcode {
 			Type::Text => {
-				count = json::decode(from_utf8(&*message.payload).unwrap()).unwrap();
+				count = serde_json::from_str(from_utf8(&*message.payload).unwrap()).unwrap();
 				println!("Will run {} cases...", count);
 			}
 			Type::Close => {

--- a/src/header/accept.rs
+++ b/src/header/accept.rs
@@ -1,9 +1,9 @@
+use base64;
 use hyper::header::{Header, HeaderFormat};
 use hyper::header::parsing::from_one_raw_str;
 use hyper;
 use std::fmt::{self, Debug};
 use std::str::FromStr;
-use serialize::base64::{ToBase64, FromBase64, STANDARD};
 use header::WebSocketKey;
 use result::{WebSocketResult, WebSocketError};
 use sha1::Sha1;
@@ -24,7 +24,7 @@ impl FromStr for WebSocketAccept {
 	type Err = WebSocketError;
 
 	fn from_str(accept: &str) -> WebSocketResult<WebSocketAccept> {
-		match accept.from_base64() {
+		match base64::decode(accept) {
 			Ok(vec) => {
 				if vec.len() != 20 {
 					return Err(WebSocketError::ProtocolError("Sec-WebSocket-Accept must be 20 bytes"));
@@ -56,7 +56,7 @@ impl WebSocketAccept {
 	/// Return the Base64 encoding of this WebSocketAccept
 	pub fn serialize(&self) -> String {
 		let WebSocketAccept(accept) = *self;
-		accept.to_base64(STANDARD)
+		base64::encode(&accept)
 	}
 }
 

--- a/src/header/key.rs
+++ b/src/header/key.rs
@@ -1,3 +1,4 @@
+use base64;
 use hyper::header::{Header, HeaderFormat};
 use hyper::header::parsing::from_one_raw_str;
 use hyper;
@@ -5,7 +6,6 @@ use std::fmt::{self, Debug};
 use rand;
 use std::mem;
 use std::str::FromStr;
-use serialize::base64::{ToBase64, FromBase64, STANDARD};
 use result::{WebSocketResult, WebSocketError};
 
 /// Represents a Sec-WebSocket-Key header.
@@ -22,7 +22,7 @@ impl FromStr for WebSocketKey {
 	type Err = WebSocketError;
 
 	fn from_str(key: &str) -> WebSocketResult<WebSocketKey> {
-		match key.from_base64() {
+		match base64::decode(key) {
 			Ok(vec) => {
 				if vec.len() != 16 {
 					return Err(WebSocketError::ProtocolError("Sec-WebSocket-Key must be 16 bytes"));
@@ -52,7 +52,7 @@ impl WebSocketKey {
 	/// Return the Base64 encoding of this WebSocketKey
 	pub fn serialize(&self) -> String {
 		let WebSocketKey(key) = *self;
-		key.to_base64(STANDARD)
+		base64::encode(&key)
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,12 +39,12 @@
 extern crate hyper;
 extern crate unicase;
 pub extern crate url;
-extern crate rustc_serialize as serialize;
 extern crate rand;
 extern crate byteorder;
 extern crate sha1;
 #[cfg(feature="ssl")]
 extern crate openssl;
+extern crate base64;
 
 #[macro_use]
 extern crate bitflags;


### PR DESCRIPTION
See #118, rustc-serialize is gone.

I didn't need serde for any of the stuff within the main library, because the only thing rustc-serialize was being used for was base64 encoding and decoding - the base64 crate was used instead.

I have added serde_json as a dev dependency, because there was some json decoding in the autobahn client.

Let me know what you think?