### PR TITLE
Expose websocket::server::upgrade::validate

### DIFF
--- a/src/server/upgrade/mod.rs
+++ b/src/server/upgrade/mod.rs
@@ -231,7 +231,8 @@ impl From<::codec::http::HttpCodecError> for HyperIntoWsError {
 }
 
 #[cfg(any(feature="sync", feature="async"))]
-fn validate(
+/// Check whether an incoming request is a valid WebSocket upgrade attempt.
+pub fn validate(
 	method: &Method,
 	version: &HttpVersion,
 	headers: &Headers,


### PR DESCRIPTION
I need to access this primitive. The API seems reasonable for public consumption and exposing it doesn't uncover any internal types.