### PR TITLE
Update base64 and replace use of deprecated Future::boxed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ bitflags = "0.9"
 rand = "0.3"
 byteorder = "1.0"
 sha1 = "0.2"
-base64 = "0.5"
+base64 = "0.6"
 futures = { version = "0.1", optional = true }
 tokio-core = { version = "0.1", optional = true }
 tokio-io = { version = "^0.1.2", optional = true }

--- a/examples/async-autobahn-client.rs
+++ b/examples/async-autobahn-client.rs
@@ -37,32 +37,30 @@ fn main() {
 						               println!("Could not receive message: {:?}", err);
 						               stream.send(OwnedMessage::Close(None)).map(|s| (None, s))
 						              })
-					      .and_then(|(msg, stream)| match msg {
-					                    Some(OwnedMessage::Text(txt)) => {
-						                    stream.send(OwnedMessage::Text(txt))
-					                              .map(|s| Loop::Continue(s))
-					                              .boxed()
-					                    }
-					                    Some(OwnedMessage::Binary(bin)) => {
-						                    stream.send(OwnedMessage::Binary(bin))
-					                              .map(|s| Loop::Continue(s))
-					                              .boxed()
-					                    }
-					                    Some(OwnedMessage::Ping(data)) => {
-						                    stream.send(OwnedMessage::Pong(data))
-					                              .map(|s| Loop::Continue(s))
-					                              .boxed()
-					                    }
-					                    Some(OwnedMessage::Close(_)) => {
-						                    stream.send(OwnedMessage::Close(None))
-					                              .map(|_| Loop::Break(()))
-					                              .boxed()
-					                    }
-					                    Some(OwnedMessage::Pong(_)) => {
-						                    future::ok(Loop::Continue(stream)).boxed()
-					                    }
-					                    None => future::ok(Loop::Break(())).boxed(),
-					                })
+					      .and_then(|(msg, stream)| -> Box<Future<Item = _, Error = _>> {
+						               match msg {
+					                       Some(OwnedMessage::Text(txt)) => {
+						                       Box::new(stream.send(OwnedMessage::Text(txt))
+					                                 .map(|s| Loop::Continue(s)))
+					                       }
+					                       Some(OwnedMessage::Binary(bin)) => {
+						                       Box::new(stream.send(OwnedMessage::Binary(bin))
+					                                 .map(|s| Loop::Continue(s)))
+					                       }
+					                       Some(OwnedMessage::Ping(data)) => {
+						                          Box::new(stream.send(OwnedMessage::Pong(data))
+					                                    .map(|s| Loop::Continue(s)))
+					                       }
+					                       Some(OwnedMessage::Close(_)) => {
+						                          Box::new(stream.send(OwnedMessage::Close(None))
+					                                    .map(|_| Loop::Break(())))
+					                       }
+					                       Some(OwnedMessage::Pong(_)) => {
+						                          Box::new(future::ok(Loop::Continue(stream)))
+					                       }
+					                       None => Box::new(future::ok(Loop::Break(()))),
+					                   }
+						              })
 				})
 			})
 			.map(move |_| {

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -540,7 +540,7 @@ impl<'u> ClientBuilder<'u> {
 		// connect to the tcp stream
 		let tcp_stream = match self.async_tcpstream(None, handle) {
 			Ok(t) => t,
-			Err(e) => return future::err(e).boxed(),
+			Err(e) => return Box::new(future::err(e)),
 		};
 
 		let builder = ClientBuilder {
@@ -557,7 +557,7 @@ impl<'u> ClientBuilder<'u> {
 			let (host, connector) = {
 				match builder.extract_host_ssl_conn(ssl_config) {
 					Ok((h, conn)) => (h.to_string(), conn),
-					Err(e) => return future::err(e).boxed(),
+					Err(e) => return Box::new(future::err(e)),
 				}
 			};
 			// secure connection, wrap with ssl
@@ -626,14 +626,14 @@ impl<'u> ClientBuilder<'u> {
 		// connect to the tcp stream
 		let tcp_stream = match self.async_tcpstream(Some(true), handle) {
 			Ok(t) => t,
-			Err(e) => return future::err(e).boxed(),
+			Err(e) => return Box::new(future::err(e)),
 		};
 
 		// configure the tls connection
 		let (host, connector) = {
 			match self.extract_host_ssl_conn(ssl_config) {
 				Ok((h, conn)) => (h.to_string(), conn),
-				Err(e) => return future::err(e).boxed(),
+				Err(e) => return Box::new(future::err(e)),
 			}
 		};
 
@@ -693,7 +693,7 @@ impl<'u> ClientBuilder<'u> {
 	pub fn async_connect_insecure(self, handle: &Handle) -> async::ClientNew<async::TcpStream> {
 		let tcp_stream = match self.async_tcpstream(Some(false), handle) {
 			Ok(t) => t,
-			Err(e) => return future::err(e).boxed(),
+			Err(e) => return Box::new(future::err(e)),
 		};
 
 		let builder = ClientBuilder {


### PR DESCRIPTION
`base64`: previously websocket had to be built with two versions of base64 (0.5 and 0.6) to support both its own use and hyper's.

`Future::boxed`: see https://github.com/alexcrichton/futures-rs/issues/556.